### PR TITLE
parser: don't escape tags on table rows

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -1306,8 +1306,7 @@ class ScenarioOutlineBuilder(object):
             if cls.is_parametrized_tag(tag):
                 # -- OOPS: Unknown placeholder, drop tag.
                 continue
-            new_tag = Tag.make_name(tag, unescape=True)
-            tags.append(new_tag)
+            tags.append(tag)
         return tags
 
     @classmethod


### PR DESCRIPTION
The only place where tags are sanitized is on table rows. This is inconsistent with Scenario tags, and makes it impossible to do things like

@fixture.my_fixture(path="C:\Windows\Temp")
Scenario Outline: My scenario outline

because the `"` and `\` are sanitized by Tag.make_name().